### PR TITLE
Rails dependency

### DIFF
--- a/commands.gemspec
+++ b/commands.gemspec
@@ -5,7 +5,5 @@ Gem::Specification.new do |s|
   s.email   = 'david@37signals.com'
   s.summary = 'Run Rake/Rails commands through the console'
 
-  s.add_dependency 'rails', '>= 3.0.0'
-
   s.files = Dir["#{File.dirname(__FILE__)}/**/*"]
 end

--- a/lib/commands.rb
+++ b/lib/commands.rb
@@ -1,3 +1,4 @@
+if defined?(Rails)
 require 'rake'
 require 'rails/generators'
 
@@ -81,3 +82,4 @@ end
 
 require 'rails/console/app'
 Rails::ConsoleMethods.send :include, Commands::ConsoleMethods
+end


### PR DESCRIPTION
Hi there,

I want to include this gem in https://github.com/nviennot/irb-config but I cannot do it because of the rails dependency.

---

By the way, you mentioned that you want to switch from env to env (https://github.com/rails/commands/blob/master/lib/commands.rb#L32-33).
I've done it  irb config: https://github.com/nviennot/irb-config/tree/master/irb/env
